### PR TITLE
Add basic community docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Stacktrace or screenshots**
+If applicable, add stacktrace or screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+### Description
+
+<!-- Please include a summary of the change or any information deemed important. -->
+
+### Related issues
+<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
+
+### Type of change
+
+<!-- Replace [ ] with [x] to select options. -->
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update (this needs a follow up PR)
+
+### Changes Made
+
+<!-- List changes made. -->
+
+### Testing
+
+<!-- Are any tests part of this PR. -->
+<!-- Replace [ ] with [x] to select options. -->
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Unit Tests
+- [ ] Integration Tests
+- [ ] Tests do not apply
+- [ ] Needs testing (start an issue or do a follow up PR about it)
+
+### Mentions
+<!-- Shout outs to your friends that you made this happen or need help. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at otto@ottoahoniemi.fi. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+## How to contribute
+
+If you're reading this, it means you saw something that is not right or you want to add a new feature. That's great, we are already glad that you can contribute.
+
+## Submitting Issues
+We have templates for submitting new issues, that you can fill out. For example if you found a bug, use the following [template to report a bug](../../issues/new?template=bug_report.md).
+
+## Submitting changes
+
+When you've made some changes you are happy with please send a [GitHub pull request](../../pull/new/master) to `master` branch with a clear list of what you've done (read more about [pull requests](https://help.github.com/en/articles/about-pull-requests)).
+
+Please follow our git branches model and coding conventions (both below), and make sure all of your commits are atomic (preferably one feature per commit). 
+
+Always write a clear log message for your commits, and if there is an issue open, reference that issue. This guide might help: [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
+
+Once submitted, we'll check the pull request.
+
+### Project structure, testing and code conventions
+
+We have a handful of rules about how we do testing, which code conventions we follow and how new additions (such as components to frontend or routes to backend) should be structured. Please check documentation for the part you're contributing to before submitting your pull request.
+
+### Git Branches
+
+We use `master` branch as the main development branch and create releases from it every now and then.
+
+When submitting changes, give your branch a short descriptive name (like the names between the `<>` below) and prefix the name with something representative for that branch:
+  - `feature/<feature-name>` - used when an enhancement or new feature was implemented
+  - `docs/<what-the-docs>` - missing docs or keeping them up to date
+  - `bugfix/<caught-it>` - solved a bug
+  - `test/<testing-that-naughty-bug>` - adding missing tests 
+  - `refactor/<that-name-is-confusing>` - well we hope we don't mess anything and we don't get to use this
+  - `hotfix/<oh-no>` - for when things needed to be fixed yesterday
+  
+  Thanks!


### PR DESCRIPTION
### Description

This PR adds basic documentation (templates, contributing guidelines etc.) to support our development workflow. 

### Related issues
Fixes #6 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

Added templates for issues, template for PRs, contribution guidelines and code of conduct.

### Testing

- [x] Tests do not apply
